### PR TITLE
Monthly Flake Upgrading (August 2024)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ $(info Current system = "$(SYSTEM)")
 test:
 	@echo Rebuild command: $(REBUILD)
 
-NIX-DARWIN := github:LnL7/nix-darwin/ec12b88104d6c117871fad55e931addac4626756
-HOME-MANAGER := github:nix-community/home-manager/0a30138c694ab3b048ac300794c2eb599dc40266
+NIX-DARWIN := github:LnL7/nix-darwin/c8d3157d1f768e382de5526bb38e74d2245cad04
+HOME-MANAGER := github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be
 
 init-ubuntu: patch-vars install-nix
 	./scripts/init-ubuntu

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720045378,
-        "narHash": "sha256-lmE7B+QXw7lWdBu5GQlUABSpzPk3YBb9VbV+IYK5djk=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0a30138c694ab3b048ac300794c2eb599dc40266",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719845423,
-        "narHash": "sha256-ZLHDmWAsHQQKnmfyhYSHJDlt8Wfjv6SQhl2qek42O7A=",
+        "lastModified": 1724994893,
+        "narHash": "sha256-yutISDGg6HUaZqCaa54EcsfTwew3vhNtt/FNXBBo44g=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ec12b88104d6c117871fad55e931addac4626756",
+        "rev": "c8d3157d1f768e382de5526bb38e74d2245cad04",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720058333,
-        "narHash": "sha256-gM2RCi5XkxmcsZ44pUkKIYBiBMfZ6u7MdcZcykmccrs=",
+        "lastModified": 1725036679,
+        "narHash": "sha256-Ri79ZOEcZJFLr6+LgS3A0WYyroL/PqEuO+lI7u+G2tE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6842b061970bf96965d66fcc86a28e1f719aae95",
+        "rev": "dac9db29e0e7ff2071ccc47b720aaffc3e74b504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Home configuration closure changes:

``` text
aws-c-auth: 0.7.22 → 0.7.25, +16.4 KiB
aws-c-common: 0.9.21 → 0.9.27, +82.1 KiB
aws-c-compression: 0.2.18 → 0.2.19
aws-c-event-stream: 0.4.2 → 0.4.3
aws-c-io: 0.14.9 → 0.14.18
aws-c-s3: 0.5.10 → 0.6.0, +16.4 KiB
aws-crt-cpp: 0.26.8 → 0.26.12, +15.3 KiB
bash: 5.2p26 → 5.2p32, -8.0 KiB
binutils: 2.41 → ∅, -13316.6 KiB
cctools: ∅ → 1010.6, +5206.7 KiB
cctools-binutils-darwin: 16.0.6-973.0.1 → 1010.6
cctools-binutils-darwin-wrapper: 16.0.6-973.0.1 → 1010.6
cctools-llvm: 16.0.6-973.0.1 → ∅
cctools-port: 973.0.1 → ∅, -11061.1 KiB
cllqwnqqr2nci1l1b3fpr9f28vd4arfq: ∅ → ε, +3381.9 KiB
cmake: 3.29.3 → 3.29.6, +756.9 KiB
curl: 8.8.0 → 8.9.0, +102.3 KiB
difftastic: 0.58.0 → 0.60.0, +2308.6 KiB
dns-root-data: 2023-11-27 → 2024-06-20
du-dust: 1.0.0 → 1.1.1, +92.5 KiB
emacs: 29.3 → 29.4, -3254.8 KiB
fd: 10.1.0 → 10.2.0, +13.2 KiB
findutils: 4.9.0 → 4.10.0, +13.4 KiB
fribidi: 1.0.13 → 1.0.15
fzf: 0.53.0 → 0.55.0, +34.5 KiB
gdbm: 1.23 → 1.24, -546.5 KiB
gh: 2.52.0 → 2.55.0, +91.3 KiB
ghostscript: ε → ∅, -47279.6 KiB
git-with-svn: 2.45.1 → 2.45.2, +1186.9 KiB
glib: 2.80.2 → 2.80.4, +190.2 KiB
gnutls: 3.8.5 → 3.8.6, +63.5 KiB
harfbuzz: 8.4.0 → 9.0.0, +186.5 KiB
icu4c: 73.2 → 74.2, -915.0 KiB
imagemagick: 7.1.1-34 → 7.1.1-37, +125.6 KiB
iterm2: 3.5.2 → 3.5.4, -5257.2 KiB
ld64: ∅ → 951.9, +5057.1 KiB
less: 643 → 661, +38.0 KiB
libX11: 1.8.9 → 1.8.10, +48.8 KiB
libaom: 3.9.0 → 3.9.1, +200.2 KiB
libedit: 20230828-3.1 → 20240517-3.1
libfido2: 1.14.0 → 1.15.0, +24.3 KiB
libheif: 1.17.6 → 1.18.0, +129.0 KiB
libjxl: 0.10.2 → 0.10.3, +262.3 KiB
libkrb5: 1.21.2 → 1.21.3, +20.3 KiB
librsvg: 2.58.1 → 2.58.2, -144.8 KiB
libtapi: 1100.0.11 → 1500.0.12.3, -15147.6 KiB
libunistring: 1.1 → 1.2, +57.3 KiB
libxml2: 2.12.7 → 2.13.3, +40.4 KiB
lld: 16.0.6 → ∅, -5045.8 KiB
llvm-binutils: 16.0.6 → ∅, -28.3 KiB
mailcap: 2.1.53 → 2.1.54
nettle: 3.9.1 → 3.10, +15.9 KiB
nghttp2: 1.61.0 → 1.62.1
nil: 2023-08-09 → 2024-08-06, +46.1 KiB
nix: 2.18.4 → 2.18.5, +277.8 KiB
nixfmt-unstable: 2024-07-03 → 2024-08-16, +79.8 KiB
nodejs: 20.12.2 → 20.15.1, +1138.8 KiB
nuspell: 5.1.4 → 5.1.6, +15.0 KiB
openldap: 2.6.7 → 2.6.8, +47.7 KiB
openpam: 20170430 → 20230627
openssl: 3.0.13 → 3.0.14, +119.8 KiB
p11-kit: 0.25.3 → 0.25.5, +241.4 KiB
pcre2: 10.43 → 10.44, +23.8 KiB
post-link-sign: ε → ∅
prettier: 3.3.2 → 3.3.3, -532.2 KiB
publicsuffix-list: 0-unstable-2024-01-07 → 0-unstable-2024-06-19, +9.6 KiB
python3: 3.11.9 → 3.12.4, +21076.6 KiB
signing: ε → ∅
sigtool: 0.1.3 → ∅, -1702.3 KiB
sqlite: 3.45.3 → 3.46.0, +81.3 KiB
starship: 1.19.0 → 1.20.1
tree: 2.1.2 → 2.1.3
tree-sitter: 0.22.5 → 0.22.6
x265: 3.5 → 3.6, +2461.9 KiB
x87qa85w82497y1anyyk8g4h4jkj4xzi: ε → ∅, -3366.3 KiB
xar: ∅ → 1.6.1, +241.4 KiB
xz: 5.4.6 → 5.6.2, +15.5 KiB
```