### PR TITLE
Monthly Flake Upgrade (September 2024)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ $(info Current system = "$(SYSTEM)")
 test:
 	@echo Rebuild command: $(REBUILD)
 
-NIX-DARWIN := github:LnL7/nix-darwin/c8d3157d1f768e382de5526bb38e74d2245cad04
-HOME-MANAGER := github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be
+NIX-DARWIN := github:LnL7/nix-darwin/f2e1c4aa29fc211947c3a7113cba1dd707433b70
+HOME-MANAGER := github:nix-community/home-manager/ffe2d07e771580a005e675108212597e5b367d2d
 
 init-ubuntu: patch-vars install-nix
 	./scripts/init-ubuntu

--- a/config/darwin.nix
+++ b/config/darwin.nix
@@ -64,6 +64,9 @@
     enableSSHSupport = true;
   };
 
+  # REVIEW: remove this after upgrading to macOS 15 Sequoia.
+  ids.uids.nixbld = 300;
+
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
   system.stateVersion = 4;

--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727537842,
-        "narHash": "sha256-KxStUlYCwvE4qTK7Wec5ZPQnwkIe09vPLXuvQJAbZd8=",
+        "lastModified": 1727588515,
+        "narHash": "sha256-5ON7WGPLODJZS8jLUV1bJlBTh6L+MiviHAz75Z9jHHM=",
         "owner": "rennsax",
         "repo": "nur-packages",
-        "rev": "aa1885d28a6392c6acd18854a98fe58569e2cf3e",
+        "rev": "ad9a6ef65f83e1c88c8ea10fcfb06c556e92c71e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1727383923,
+        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724994893,
-        "narHash": "sha256-yutISDGg6HUaZqCaa54EcsfTwew3vhNtt/FNXBBo44g=",
+        "lastModified": 1727507295,
+        "narHash": "sha256-I/FrX1peu4URoj5T5odfuKR2rm4GjYJJpCGF9c0/lDA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c8d3157d1f768e382de5526bb38e74d2245cad04",
+        "rev": "f2e1c4aa29fc211947c3a7113cba1dd707433b70",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725036679,
-        "narHash": "sha256-Ri79ZOEcZJFLr6+LgS3A0WYyroL/PqEuO+lI7u+G2tE=",
+        "lastModified": 1727492312,
+        "narHash": "sha256-oRkgc+DosM3HIl9el98TxF2rtliKHCNVw00nlQC7xYM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dac9db29e0e7ff2071ccc47b720aaffc3e74b504",
+        "rev": "4471f9f67fe0f95f5fec4cc2ebac59fe32af2b62",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -81,17 +81,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1726909044,
-        "narHash": "sha256-+y1+pMtsyI4yWSR62DUD39trhwYAe2eYJTPK+GmVJKQ=",
-        "ref": "refs/heads/master",
-        "rev": "b59686e152cdfc024bce42d29f14ad723f4ad0f5",
-        "revCount": 8,
-        "type": "git",
-        "url": "ssh://git@github.com/rennsax/nur-packages"
+        "lastModified": 1727537842,
+        "narHash": "sha256-KxStUlYCwvE4qTK7Wec5ZPQnwkIe09vPLXuvQJAbZd8=",
+        "owner": "rennsax",
+        "repo": "nur-packages",
+        "rev": "aa1885d28a6392c6acd18854a98fe58569e2cf3e",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/rennsax/nur-packages"
+        "owner": "rennsax",
+        "repo": "nur-packages",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     nur-rennsax = {
-      url = "git+ssh://git@github.com/rennsax/nur-packages";
+      url = "github:rennsax/nur-packages";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -123,6 +123,7 @@
           ./config/home/base.nix
           ./config/home/nix-scripts.nix
           ./config/home/develop.nix
+          ./config/home/text-configs.nix
         ]
         // combinedHome "minimal" [
           ./config/home/general.nix


### PR DESCRIPTION
Nixpkgs:
``` text
dac9db29e0e7ff2071ccc47b720aaffc3e74b504 → 4471f9f67fe0f95f5fec4cc2ebac59fe32af2b62
```

Other:
``` text
darwin-system: 24.11.20240830.dac9db2+darwin4.c8d3157, 24.11pre-git+darwin4 → 24.11.20240928.4471f9f+darwin4.f2e1c4a, 24.11pre-git+darwin5
nano: 8.1 → 8.2
nix: 2.18.5 → 2.18.8
vim: 9.1.0595 → 9.1.0707, +109.6 KiB
apr: 1.7.4 → 1.7.5
aws-c-auth: 0.7.25 → 0.7.26
curl: 8.9.0 → 8.9.1
gh: 2.55.0 → 2.57.0, +100.4 KiB
git-with-svn: 2.45.2 → 2.46.0, -226.0 KiB
hostname-shell_cmds: 187 → ∅
imagemagick: 7.1.1-37 → 7.1.1-38, +16.3 KiB
inetutils: ∅ → 2.5, +2193.2 KiB
krb5: ∅ → 1.21.3, +2971.6 KiB
libedit: 20240517-3.1 → 20240808-3.1
libheif: 1.18.0 → 1.18.2, +17.2 KiB
libkrb5: 1.21.3 → ∅, -2386.6 KiB
lua: 5.4.6 → 5.4.7, +16.3 KiB
nix: 2.18.5 → 2.18.8
nix-direnv: 3.0.5 → 3.0.6
nodejs: 20.15.1 → 20.17.0, +293.3 KiB
publicsuffix-list: 0-unstable-2024-06-19 → 0-unstable-2024-08-21
python3: 3.12.4 → 3.12.5, -265.1 KiB
python3.12-ipython: 8.25.0 → 8.26.0
ripgrep: 14.1.0 → 14.1.1, +55.1 KiB
shell_cmds: 187 → ∅, -2489.0 KiB
unbound: 1.20.0 → 1.21.0, +16.5 KiB
xar: 1.6.1 → 498, -89.4 KiB
xmake: ∅ → 2.9.5, +6892.8 KiB
```